### PR TITLE
openfoam : possible improvements for build

### DIFF
--- a/openfoam-esi/PKGBUILD
+++ b/openfoam-esi/PKGBUILD
@@ -4,12 +4,16 @@
 # Contributor: Andrew Fischer <andrew_at_apastron.co>
 # Contributor: <gucong43216@gmail.com>
 
+# consider this?
+#   pkgname=openfoam-com ?
+#   conflicts=("openfoam")
+
 pkgname=openfoam-esi
 pkgver=v2006
 _distname=OpenFOAM
 _dist=$_distname-$pkgver
 pkgrel=3
-pkgdesc="The open source CFD toolbox (ESI-OpenCFD version)"
+pkgdesc="The open source CFD toolbox (www.openfoam.com)"
 arch=('i686' 'x86_64')
 url="http://www.openfoam.com/"
 license=('GPL')
@@ -21,56 +25,103 @@ source=("https://sourceforge.net/projects/openfoam/files/v2006/OpenFOAM-v2006.tg
 md5sums=('1226d48e74a4c78f12396cb586c331d8')
 
 prepare() {
-  if [ $WM_PROJECT_DIR ]
+  if [ -n "$WM_PROJECT_DIR" ]
   then
-    echo " "
+    echo
     echo -e "\e[1m\e[5m\e[31mPlease make sure that no OpenFOAM version is sourced in bashrc.\e[0m"
-    echo " "
+    echo
     return 1
   fi
 
-  # Extract the current version and major of paraview and of scotch for use in the system preferences
+  # Extract the current version and major of paraview for use in the system preferences
   _pversion=$(pacman -Q $(pacman -Qqo $(which paraview)) | sed -e 's/.* //; s/-.*//g')
-  _pmajor=`echo $_pversion | cut -d '.' -f1`
+  _pmajor="${_pversion%%.*}"
+
+  projectDir="${srcdir}/${_distname}-${pkgver}"
 
   # Generate and install the system preferences file
-  echo "export compilerInstall=system" > ${srcdir}/prefs.sh
-  echo "export WM_MPLIB=SYSTEMOPENMPI" >> ${srcdir}/prefs.sh
-  echo "export ParaView_VERSION=${_pversion}" >> ${srcdir}/prefs.sh
-  echo "export ParaView_MAJOR=${_pmajor}" >> ${srcdir}/prefs.sh
-  cp ${srcdir}/prefs.sh ${srcdir}/${_distname}-${pkgver}/etc
+  echo "# Preferences for arch-linux
 
-  # Generate the scotch.sh file for arch
-  echo "export SCOTCH_VERSION=scotch-system" > ${srcdir}/scotch
-  cp ${srcdir}/scotch ${srcdir}/${_distname}-${pkgver}/etc/config.sh
+export WM_COMPILER_TYPE=system
+export WM_MPLIB=SYSTEMOPENMPI
+
+export ParaView_VERSION=${_pversion}
+export ParaView_MAJOR=${_pmajor}
+# End" \
+  > "${projectDir}"/etc/prefs.sh
+
+
+  # Configure components.
+  # Use system values for boost/cgal, fftw, scotch
+  # could also manage paraview here?
+
+  "${projectDir}"/bin/tools/foamConfigurePaths \
+    -boost boost-system \
+    -cgal  cgal-system \
+    -fftw  fftw-system \
+    -kahip kahip-none \
+    -scotch scotch-system \
+    ;
 }
 
-build() {
 
-  if [ $WM_PROJECT_DIR ]
-  then 
-    echo " "
+build() {
+  if [ -n "$WM_PROJECT_DIR" ]
+  then
+    echo
     echo -e "\e[1m\e[5m\e[31mPlease make sure that no OpenFOAM version is sourced in bashrc.\e[0m"
-    echo " "
+    echo
     return 1
   fi
 
-  export FOAM_INST_DIR=${srcdir}
-  foamDotFile=${srcdir}/${_dist}/etc/bashrc
-  [ -f ${foamDotFile} ] || return 1
-  # without && echo " ", makepkg fails
-  source ${foamDotFile} && echo " "
+  projectDir="${srcdir}/${_dist}"
+  [ -f "$projectDir/etc/bashrc" ] || {
+      echo "No $projectDir/etc/bashrc found"
+      return 1
+  }
 
-  cd "$srcdir/$_dist"
-  ./Allwmake -j `nproc` 2>&1 | tee log.wmake
+  # Avoid external influence on the environment
+  export FOAM_CONFIG_MODE="o"
+  unset FOAM_SETTINGS
 
-  # check if an error occured during build
-  ret="${PIPESTATUS[0]}"
-  [[ "$ret" -ne "0" ]] && exit 1
 
-  wclean all || exit 1
-  wmakeLnIncludeAll || exit 1
+  set +e  # Turn errexit off
+  source "$projectDir"/etc/bashrc '' || \
+    echo "Ignore spurious sourcing error"
+  set -e  # Turn errexit back on
+
+  cd "$projectDir" || exit
+
+  ./Allwmake -j -log=log.build
+
+  # Check log for this type of content:
+  #
+  #   api   = 2006
+  #   patch = 1
+  #   bin   = 283 entries
+  #   lib   = 139 entries
+
+  [ -f log.build ] || {
+      echo "No log.build file - build failed entirely"
+      exit 1
+  }
+
+  bins="$( cat log.build | sed -ne 's/.*bin *= *\([0-9][0-9]*\).*/\1/p;' | sed -ne '$p' )"
+  libs="$( cat log.build | sed -ne 's/.*lib *= *\([0-9][0-9]*\).*/\1/p;' | sed -ne '$p' )"
+
+  if [ "${bins:=0}" = 0 ] || [ "${libs:=0}" = 0 ]
+  then
+      echo
+      echo "Build failed with $bins executables and $libs libraries"
+      echo "Check the log.build file"
+      echo
+      exit 1
+  fi
+
+  # Remove intermediate build artifacts
+  rm -rf "${projectDir}/build"
 }
+
 
 package() {
   cd ${srcdir}
@@ -90,3 +141,5 @@ package() {
   echo "alias of=\"source /opt/${_distname}/${_dist}/etc/bashrc\"" >> ~/.bashrc
   echo "alias paraFoam=\"paraFoam -builtin\"" >> ~/.bashrc
 }
+
+# ---------------------------------------------------------------------------

--- a/openfoam-esi/PKGBUILD
+++ b/openfoam-esi/PKGBUILD
@@ -8,6 +8,9 @@
 #   pkgname=openfoam-com ?
 #   conflicts=("openfoam")
 
+# Installs as (for example)
+#     /opt/OpenFOAM/OpenFOAM-v2006
+
 pkgname=openfoam-esi
 pkgver=v2006
 _distname=OpenFOAM
@@ -37,7 +40,7 @@ prepare() {
   _pversion=$(pacman -Q $(pacman -Qqo $(which paraview)) | sed -e 's/.* //; s/-.*//g')
   _pmajor="${_pversion%%.*}"
 
-  projectDir="${srcdir}/${_distname}-${pkgver}"
+  projectDir="${srcdir}/${_dist}"
 
   # Generate and install the system preferences file
   echo "# Preferences for arch-linux
@@ -126,20 +129,40 @@ build() {
 package() {
   cd ${srcdir}
 
-  # Create destination directories
-  install -d ${pkgdir}/opt/${_distname} ${pkgdir}/etc/profile.d || return 1
+  # Installation directories
+  parentDir="${pkgdir}/opt/${_distname}"
+  projectDir="${parentDir}/${_dist}"
 
-  # copy package to pkgdir
-  cp -r "${srcdir}/${_dist}" "${pkgdir}/opt/${_distname}" || return 1
+  # Create destination directories
+  install -d "${parentDir}" "${pkgdir}"/etc/profile.d || return 1
+
+  # Copy package to pkgdir
+  cp -r "${srcdir}/${_dist}" "${parentDir}" || return 1
 
   # Permission fixes - for system-wide install and use
-  chmod -R go+r ${pkgdir}/opt
-  chmod -R 755 ${pkgdir}/opt/${_distname}/${_dist}/bin
-  chmod -R 755 ${pkgdir}/opt/${_distname}/${_dist}/etc
+  chmod -R go+r "${pkgdir}"/opt
+  chmod -R 755 "${projectDir}"/bin
+  chmod -R 755 "${projectDir}"/etc
+
+  [ -e "${projectDir}"/ThirdParty ] || \
+      echo "system dependencies" >| "${projectDir}"/ThirdParty
+
+#  # Install shell-session script. Could be via post-install
+#  session="/usr/bin/openfoam${pkgver#v}"
+#  wrapper="$projectDir/bin/tools/openfoam.in"
+#
+#  if [ -f "$wrapper" ]
+#  then
+#      echo "Create $session"
+#      sed -e "s#@PROJECT_DIR@#${projectDir}#" "$wrapper" >| "$session"
+#      chmod 0755 "$session"
+#  else
+#      echo "No method to create $session for openfoam${pkgver#v}"
+#  fi
 
   # create alias in .bashrc
-  echo "alias of=\"source /opt/${_distname}/${_dist}/etc/bashrc\"" >> ~/.bashrc
-  echo "alias paraFoam=\"paraFoam -builtin\"" >> ~/.bashrc
+  echo "alias of='source ${projectDir}/etc/bashrc'" >> ~/.bashrc
+  echo "alias paraFoam='paraFoam -builtin'" >> ~/.bashrc
 }
 
 # ---------------------------------------------------------------------------

--- a/openfoam/PKGBUILD
+++ b/openfoam/PKGBUILD
@@ -3,13 +3,17 @@
 # Contributor: George Eleftheriou <eleftg>
 # Contributor: Andrew Fischer <andrew_at_apastron.co>
 
+# consider this?
+#   pkgname=openfoam-org ?
+#   conflicts=("openfoam")
+
 pkgname=openfoam
 _subver=version-8
 _pkgver=8
 #pkgver=${_pkgver}.${_subver}
 pkgver=${_pkgver}
 pkgrel=1
-pkgdesc="The open source CFD toolbox"
+pkgdesc="The open source CFD toolbox (www.openfoam.org)"
 _distpkgname=OpenFOAM
 _gitname=$_distpkgname-$_pkgver
 arch=('x86_64')

--- a/openfoam/PKGBUILD
+++ b/openfoam/PKGBUILD
@@ -7,6 +7,12 @@
 #   pkgname=openfoam-org ?
 #   conflicts=("openfoam")
 
+# Installs as (for example)
+#     /opt/OpenFOAM/OpenFOAM-8
+#
+# with additional stub directory
+#     /opt/OpenFOAM/ThirdParty-8
+
 pkgname=openfoam
 _subver=version-8
 _pkgver=8
@@ -66,24 +72,27 @@ build() {
 package() {
   cd ${srcdir}
 
+  # Installation directories
+  parentDir="${pkgdir}/opt/${_distpkgname}"
+  projectDir="${parentDir}/${_distpkgname}-${_pkgver}"
+
   # Create destination directories
-  install -d ${pkgdir}/opt/${_distpkgname} ${pkgdir}/etc/profile.d || return 1
+  install -d "${parentDir}" "${pkgdir}"/etc/profile.d || return 1
 
-  # copy package to pkgdir
-  cp -r ${srcdir}/${_distpkgname}-${_pkgver} ${pkgdir}/opt/${_distpkgname} || return 1
-
-  # Add source file
-  echo "export FOAM_INST_DIR=/opt/${_distpkgname}" > ${pkgdir}/etc/profile.d/openfoam-${_pkgver}.sh || return 1
-  echo "alias ofoam=\"source \${FOAM_INST_DIR}/${_distpkgname}-${_pkgver}/etc/bashrc\"" >> ${pkgdir}/etc/profile.d/openfoam-${_pkgver}.sh || return 1
-  chmod 755 ${pkgdir}/etc/profile.d/openfoam-${_pkgver}.sh || return 1
-
-  # Add stub thirdparty directory to keep openfoam happy
-  install -d ${pkgdir}/opt/${_distpkgname}/ThirdParty-${_pkgver} || return 1
+  # Copy package to pkgdir
+  cp -r "${srcdir}/${_distpkgname}-${_pkgver}" "${parentDir}" || return 1
 
   # Permission fixes - for system-wide install and use
-  chmod -R go+r ${pkgdir}/opt
-  chmod -R 755 ${pkgdir}/opt/${_distpkgname}/${_distpkgname}-${_pkgver}/bin
-  chmod -R 755 ${pkgdir}/opt/${_distpkgname}/${_distpkgname}-${_pkgver}/etc
+  chmod -R go+r "${pkgdir}"/opt
+  chmod -R 755 "${projectDir}"/bin
+  chmod -R 755 "${projectDir}"/etc
+
+  # Add stub thirdparty directory to keep openfoam happy
+  install -d "${parentDir}/ThirdParty-${_pkgver}" || return 1
+
+  # Add source file
+  echo "alias ofoam='source ${projectDir}/etc/bashrc'" >> ${pkgdir}/etc/profile.d/openfoam-${_pkgver}.sh || return 1
+  chmod 755 ${pkgdir}/etc/profile.d/openfoam-${_pkgver}.sh || return 1
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
These reflect how we typically configure and build OpenFOAM for debian and rpm. See our [standard openfoam rpm template](https://develop.openfoam.com/Development/openfoam/-/wikis/packaging/common/openfoamVERSION.spec) as well as the [debian recipe](https://salsa.debian.org/olesenm/openfoam/-/blob/master/debian/rules#L161) for more details 

The configure command is the same that we also use in the [spack openfoam recipe](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/openfoam/package.py).

Note that the changes proposed here have ***not yet been tested*** on an arch linux system, but I wanted to get them out there for discussion and possible integration.

FYI: @MakisH

/mark

