### PR TITLE
Add metis

### DIFF
--- a/x86_64/coin-or-coinmumps/cactus.yaml
+++ b/x86_64/coin-or-coinmumps/cactus.yaml
@@ -1,1 +1,8 @@
-../../template/x86_64-simple.yaml
+nvchecker:
+  - source: aur
+    aur:
+depends:
+  - x86_64/metis
+build_prefix: extra-x86_64
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/x86_64/gmsh/cactus.yaml
+++ b/x86_64/gmsh/cactus.yaml
@@ -4,6 +4,7 @@ nvchecker:
   - alias: python
 depends:
   - x86_64/ann
+  - x86_64/metis
   - x86_64/voro++
 build_prefix: extra-x86_64
 pre_build: |

--- a/x86_64/kahip/cactus.yaml
+++ b/x86_64/kahip/cactus.yaml
@@ -1,1 +1,8 @@
-../../template/x86_64-simple.yaml
+nvchecker:
+  - source: aur
+    aur:
+depends:
+  - x86_64/metis
+build_prefix: extra-x86_64
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/x86_64/metis/cactus.yaml
+++ b/x86_64/metis/cactus.yaml
@@ -1,0 +1,1 @@
+../../template/x86_64-simple.yaml

--- a/x86_64/mumps-par/cactus.yaml
+++ b/x86_64/mumps-par/cactus.yaml
@@ -2,9 +2,10 @@ nvchecker:
   - source: aur
     aur:
 depends:
+  - x86_64/metis
   - x86_64/parmetis
-  - x86_64/scalapack
   - x86_64/scotch
+  - x86_64/scalapack
 build_prefix: extra-x86_64
 pre_build: aur-pre-build
 post_build: aur-post-build

--- a/x86_64/mumps/cactus.yaml
+++ b/x86_64/mumps/cactus.yaml
@@ -2,9 +2,9 @@ nvchecker:
   - source: aur
     aur:
 depends:
-  - x86_64/scalapack
+  - x86_64/metis
   - x86_64/scotch
+  - x86_64/scalapack
 build_prefix: extra-x86_64
-makepkg_args: --nocheck
 pre_build: aur-pre-build
 post_build: aur-post-build


### PR DESCRIPTION
Today [`metis`](https://aur.archlinux.org/packages/metis) was moved from `[community]` to `[aur]`. This package is a dependency for some packages like `parmetis`, `coin-or-coinmumps`, `gmsh`, `kahip`, `mumps-par`, `mumps`.