### PR TITLE
Add real PETSc to the repository with its makedependencies

### DIFF
--- a/x86_64/petsc/cactus.yaml
+++ b/x86_64/petsc/cactus.yaml
@@ -1,0 +1,16 @@
+nvchecker:
+  - source: aur
+    aur:
+makedepends:
+  - x86_64/hypre
+  - x86_64/mumps
+  - x86_64/parmetis
+  - x86_64/pastix
+  - x86_64/scotch
+  - x86_64/superlu_dist
+  - x86_64/archimedes-tools: triangle
+build_prefix: extra-x86_64
+pre_build: |
+  aur-pre-build
+  add makedepends fftw hdf5-openmpi hypre metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
+post_build: aur-post-build


### PR DESCRIPTION
First we add the [`petsc`](https://aur.archlinux.org/packages/petsc) package to `arch4edu` repository. This package opens the possibilities of including several packages (23). Remark, [since the last commit, real `petsc` supports `superlu_dist`](https://aur.archlinux.org/cgit/aur.git/commit/?h=petsc&id=ff25819a8cbb4c8ac43f98d4d726099c163da206).

It will be the first step in order to fix #187 . Later, `petsc` will be set as a dependency for [`dolfinx`](https://aur.archlinux.org/packages/dolfinx).