### PR TITLE
Package requests python-trimesh

### DIFF
--- a/any/python-trimesh/cactus.yaml
+++ b/any/python-trimesh/cactus.yaml
@@ -1,0 +1,1 @@
+../../template/x86_64-python.yaml


### PR DESCRIPTION
[trimesh](https://trimsh.org) is python module used for triangular meshes, quite popular in AUR.