### PR TITLE
Disable hypre due to incompatibilities for PETSc

### DIFF
--- a/x86_64/dolfinx/cactus.yaml
+++ b/x86_64/dolfinx/cactus.yaml
@@ -8,7 +8,6 @@ depends:
   - x86_64/parmetis
   - x86_64/petsc
 makedepends:
-  - x86_64/hypre
   - x86_64/mumps
   - x86_64/parmetis
   - x86_64/pastix
@@ -19,5 +18,5 @@ build_prefix: extra-x86_64
 makepkg_args: --nocheck
 pre_build: |
   aur-pre-build
-  add makedepends fftw hdf5-openmpi hypre metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
+  add makedepends fftw hdf5-openmpi metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
 post_build: aur-post-build

--- a/x86_64/petsc-complex/cactus.yaml
+++ b/x86_64/petsc-complex/cactus.yaml
@@ -2,7 +2,6 @@ nvchecker:
   - source: aur
     aur:
 makedepends:
-  - x86_64/hypre
   - x86_64/mumps
   - x86_64/parmetis
   - x86_64/pastix
@@ -12,5 +11,5 @@ makedepends:
 build_prefix: extra-x86_64
 pre_build: |
   aur-pre-build
-  add makedepends fftw hdf5-openmpi hypre metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
+  add makedepends fftw hdf5-openmpi metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
 post_build: aur-post-build

--- a/x86_64/petsc/cactus.yaml
+++ b/x86_64/petsc/cactus.yaml
@@ -2,7 +2,6 @@ nvchecker:
   - source: aur
     aur:
 makedepends:
-  - x86_64/hypre
   - x86_64/mumps
   - x86_64/parmetis
   - x86_64/pastix
@@ -12,5 +11,5 @@ makedepends:
 build_prefix: extra-x86_64
 pre_build: |
   aur-pre-build
-  add makedepends fftw hdf5-openmpi hypre metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
+  add makedepends fftw hdf5-openmpi metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
 post_build: aur-post-build

--- a/x86_64/python-fenics-dolfinx/cactus.yaml
+++ b/x86_64/python-fenics-dolfinx/cactus.yaml
@@ -6,7 +6,6 @@ depends:
   - x86_64/dolfinx
 makedepends:
   - any/python-cppimport
-  - x86_64/hypre
   - x86_64/mumps
   - x86_64/parmetis
   - x86_64/pastix
@@ -16,5 +15,5 @@ makedepends:
 build_prefix: extra-x86_64
 pre_build: |
   aur-pre-build
-  add makedepends fftw hdf5-openmpi hypre metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
+  add makedepends fftw hdf5-openmpi metis mumps parmetis pastix scotch suitesparse superlu superlu_dist triangle valgrind
 post_build: aur-post-build


### PR DESCRIPTION
Side note:

- Since PETSc 3.20 or later will support cython 3.0 or later (schedule for end of september). https://aur.archlinux.org/packages/petsc#comment-925674
- Since `metis` got upgrade and now depends of `gkilib`, parmetis is not compiling, so it  can be used https://aur.archlinux.org/packages/parmetis-git, but not tested for upstream.
https://gitlab.com/petsc/petsc/-/issues/1294