### PR TITLE
[package request] nanobind

### DIFF
--- a/any/nanobind/cactus.yaml
+++ b/any/nanobind/cactus.yaml
@@ -1,0 +1,9 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+makedepends:
+  - x86_64/python-jax
+build_prefix: extra-x86_64
+pre_build: aur-pre-build
+post_build: aur-post-build


### PR DESCRIPTION
pybind11 now superseeded by nanobind as makedependency python-fenics-basix.