### PR TITLE
[package request] pypy3-build, pypy3-flit-core, pypy3-installer

### DIFF
--- a/any/pypy3-build/cactus.yaml
+++ b/any/pypy3-build/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+makedepends:
+  - any/pypy-setuptools: pypy3-setuptools
+build_prefix: extra-x86_64
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/pypy3-flit-core/cactus.yaml
+++ b/any/pypy3-flit-core/cactus.yaml
@@ -1,0 +1,9 @@
+nvchecker:
+  - source: aur
+    aur:
+makedepends:
+  - any/pypy3-build
+  - any/pypy3-installer
+build_prefix: extra-x86_64
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/pypy3-installer/cactus.yaml
+++ b/any/pypy3-installer/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+makedepends:
+  - any/pypy-setuptools: pypy3-setuptools
+build_prefix: extra-x86_64
+pre_build: aur-pre-build
+post_build: aur-post-build


### PR DESCRIPTION
Since that [`python setup.py build`](https://packaging.python.org/en/latest/guides/modernize-setup-py-project) command will be deprecated soon (pypy3 is now 3.10), we must follow [PEP 517](https://peps.python.org/pep-0517). So, let's add to the repository.

Note that in next versions:
- `pypy3-build` will have a makedependency for itself as https://archlinux.org/packages/extra/any/python-build.
- `pypy3-installer` wil have makedependency for `pypy3-flit-core` and `pypy3-build` as https://archlinux.org/packages/extra/any/python-installer

In previous step will required `python-dephell` from newer versions that do not include setup.py but not depends from `pypy3-build` and `pypy3-installer`, now in AUR and archived, but [Arch Linux Maintainers do it the trick some time ago](https://gitlab.archlinux.org/archlinux/packaging/packages/python-installer/-/commit/66b66725717462c62789f3ba0647c64b3bbffc92#9b9baac1eb9b72790eef5540a1685306fc43fd6c_0_21) and we will add in the repository temporally because works with a small patch.