### PR TITLE
Add python-dephell, will use for pypy3-installer temporaly

### DIFF
--- a/any/python-dephell-archive/cactus.yaml
+++ b/any/python-dephell-archive/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-argparse/cactus.yaml
+++ b/any/python-dephell-argparse/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-changelogs/cactus.yaml
+++ b/any/python-dephell-changelogs/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-discover/cactus.yaml
+++ b/any/python-dephell-discover/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-licenses/cactus.yaml
+++ b/any/python-dephell-licenses/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-links/cactus.yaml
+++ b/any/python-dephell-links/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-markers/cactus.yaml
+++ b/any/python-dephell-markers/cactus.yaml
@@ -1,0 +1,10 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+depends:
+  - any/python-dephell-specifier
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-pythons/cactus.yaml
+++ b/any/python-dephell-pythons/cactus.yaml
@@ -1,0 +1,10 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+depends:
+  - any/python-dephell-specifier
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-setuptools/cactus.yaml
+++ b/any/python-dephell-setuptools/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-shells/cactus.yaml
+++ b/any/python-dephell-shells/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-specifier/cactus.yaml
+++ b/any/python-dephell-specifier/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-venvs/cactus.yaml
+++ b/any/python-dephell-venvs/cactus.yaml
@@ -1,0 +1,10 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+depends:
+  - any/python-dephell-pythons
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell-versioning/cactus.yaml
+++ b/any/python-dephell-versioning/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-dephell/cactus.yaml
+++ b/any/python-dephell/cactus.yaml
@@ -1,0 +1,27 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+depends:
+  - any/python-dephell-archive
+  - any/python-dephell-argparse
+  - any/python-dephell-changelogs
+  - any/python-dephell-discover
+  - any/python-dephell-licenses
+  - any/python-dephell-links
+  - any/python-dephell-markers
+  - any/python-dephell-pythons
+  - any/python-dephell-setuptools
+  - any/python-dephell-shells
+  - any/python-dephell-specifier
+  - any/python-dephell-venvs
+  - any/python-dephell-versioning
+  - any/python-m2r2
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: |
+  aur-pre-build
+  sed 's|m2r|m2r2|' -i PKGBUILD
+  sed '76 a sed -i "s/m2r/m2r2/" dephell/controllers/_readme.py' -i PKGBUILD
+  sed '76 a sed -i "s/m2r/m2r2/" setup.py' -i PKGBUILD
+post_build: aur-post-build

--- a/any/python-m2r2/cactus.yaml
+++ b/any/python-m2r2/cactus.yaml
@@ -1,0 +1,10 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+depends:
+  - any/python-mistune1
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/any/python-mistune1/cactus.yaml
+++ b/any/python-mistune1/cactus.yaml
@@ -1,0 +1,8 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build


### PR DESCRIPTION
Let's add python-dephell for build pypy3-installer, after build pypy3-flit-core will not be necessary.