### PR TITLE
[package request] pypy3-setuptools70

### DIFF
--- a/any/pypy3-setuptools70/cactus.yaml
+++ b/any/pypy3-setuptools70/cactus.yaml
@@ -1,0 +1,1 @@
+../../template/x86_64-simple.yaml


### PR DESCRIPTION
`pypy3-packaging<22` is not compatible with `pypy3-setuptools`, so we add a compatible one.

The [issue](https://github.com/pypa/setuptools/issues/4483) is fixed with `pypy3-packaging>=22` but they are using `flit-core` and not `setuptools` as backend.