### PR TITLE
[package request] pypy3-pyproject-hooks

### DIFF
--- a/any/pypy3-pyproject-hooks/cactus.yaml
+++ b/any/pypy3-pyproject-hooks/cactus.yaml
@@ -1,0 +1,11 @@
+nvchecker:
+  - source: aur
+    aur:
+makedepends:
+  - any/pypy3-build
+  - any/pypy3-installer
+  - any/pypy3-flit-core
+build_prefix: extra-x86_64
+makepkg_args: --nocheck
+pre_build: aur-pre-build
+post_build: aur-post-build


### PR DESCRIPTION
`pypy3-pyproject-hooks` will be a dependency for newer versions of `pypy3-build`.