### PR TITLE
Add `x86_64/open3d` with dependencies

### DIFF
--- a/x86_64/nanoflann/cactus.yaml
+++ b/x86_64/nanoflann/cactus.yaml
@@ -1,0 +1,1 @@
+../../template/x86_64-simple.yaml

--- a/x86_64/open3d/cactus.yaml
+++ b/x86_64/open3d/cactus.yaml
@@ -1,0 +1,11 @@
+nvchecker:
+  - source: aur
+    aur:
+  - alias: python
+depends:
+  - x86_64/python-dash
+  - x86_64/nanoflann
+  - x86_64/mysql
+build_prefix: extra-x86_64
+pre_build: aur-pre-build
+post_build: aur-post-build

--- a/x86_64/python-dash/cactus.yaml
+++ b/x86_64/python-dash/cactus.yaml
@@ -1,0 +1,1 @@
+../../template/x86_64-python.yaml


### PR DESCRIPTION
open3d is both a python wheel and c++ library which has quite a heavy build, so I suppose it would be a sensible addition to arch4edu.